### PR TITLE
[codeguard/codeguard#1831] Change the commit kept after pruning

### DIFF
--- a/lib/git/tail/runner.rb
+++ b/lib/git/tail/runner.rb
@@ -72,15 +72,13 @@ module Git
         # make sure it's only in one.
         new_log_entries.pop if new_log_entries.last == old_log_entries.first
 
-        if old_log_entries.empty?
+        if old_log_entries.count <= 1
           out :detail, 2, "No commits prior to cutoff date. Skipping."
-        elsif new_log_entries.empty?
-          out :detail, 2, "No commits after cutoff date. Skipping."
         else
           build_commit_map(branch) if replace
 
           out :detail, 4, "Truncating #{old_log_entries.length} commits..."
-          old_base = Commit.new(new_log_entries.last)
+          old_base = Commit.new(old_log_entries.first)
 
           tree = Git.command 'rev-parse', "#{old_base.hash}^{tree}"
           new_base = Git.command 'commit-tree',

--- a/lib/git/tail/runner.rb
+++ b/lib/git/tail/runner.rb
@@ -73,11 +73,11 @@ module Git
         new_log_entries.pop if new_log_entries.last == old_log_entries.first
 
         if old_log_entries.count <= 1
-          out :detail, 2, "No commits prior to cutoff date. Skipping."
+          out :detail, 2, "No prunable commits prior to cutoff date. Skipping."
         else
           build_commit_map(branch) if replace
 
-          out :detail, 4, "Truncating #{old_log_entries.length} commits..."
+          out :detail, 4, "Truncating #{old_log_entries.length - 1} commits..."
           old_base = Commit.new(old_log_entries.first)
 
           tree = Git.command 'rev-parse', "#{old_base.hash}^{tree}"

--- a/lib/git/tail/version.rb
+++ b/lib/git/tail/version.rb
@@ -1,5 +1,5 @@
 module Git
   module Tail
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end


### PR DESCRIPTION
Rather than keeping the oldest commit after the cutoff date, keep the most recent commit prior to the cutoff date.

Visual representation:

```
Newest           Oldest
x x x x x x | x x x x x
   Cutoff --^

              v-- Keep this one
x x x x x x | x x x x x
          ^-- Not this one
```

This change will help us address codeguard/codeguard#1831
